### PR TITLE
Add secure dashboard for monitoring and token management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 .DS_Store
 *.txt
+token-store.json

--- a/auth.js
+++ b/auth.js
@@ -1,138 +1,96 @@
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
 import fetch from 'node-fetch';
 import { logDebug, logError, logInfo } from './logger.js';
-
-// State management for API key and refresh
-let currentApiKey = null;
-let currentRefreshToken = null;
-let lastRefreshTime = null;
-let clientId = null;
-let authSource = null; // 'env' or 'file' or 'factory_key' or 'client'
-let authFilePath = null;
-let factoryApiKey = null; // From FACTORY_API_KEY environment variable
+import {
+  activateToken,
+  getActiveFactoryKey,
+  getActiveRefreshToken,
+  initializeDashboardState,
+  maskToken,
+  updateAuthStatus,
+  updateTokenValue
+} from './state.js';
 
 const REFRESH_URL = 'https://api.workos.com/user_management/authenticate';
-const REFRESH_INTERVAL_HOURS = 6; // Refresh every 6 hours
-const TOKEN_VALID_HOURS = 8; // Token valid for 8 hours
+const REFRESH_INTERVAL_HOURS = 6;
+const AUTH_TOKEN = process.env.AUTH_TOKEN ? process.env.AUTH_TOKEN.trim() : null;
 
-/**
- * Generate a ULID (Universally Unique Lexicographically Sortable Identifier)
- * Format: 26 characters using Crockford's Base32
- * First 10 chars: timestamp (48 bits)
- * Last 16 chars: random (80 bits)
- */
-function generateULID() {
-  // Crockford's Base32 alphabet (no I, L, O, U to avoid confusion)
-  const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
-  
-  // Get timestamp in milliseconds
-  const timestamp = Date.now();
-  
-  // Encode timestamp to 10 characters
-  let time = '';
-  let ts = timestamp;
-  for (let i = 9; i >= 0; i--) {
-    const mod = ts % 32;
-    time = ENCODING[mod] + time;
-    ts = Math.floor(ts / 32);
-  }
-  
-  // Generate 16 random characters
-  let randomPart = '';
-  for (let i = 0; i < 16; i++) {
-    const rand = Math.floor(Math.random() * 32);
-    randomPart += ENCODING[rand];
-  }
-  
-  return time + randomPart;
-}
+let currentApiKey = null;
+let lastRefreshTime = null;
+let cachedRefreshTokenId = null;
+let cachedRefreshTokenValue = null;
+let clientId = null;
 
-/**
- * Generate a client ID in format: client_01{ULID}
- */
-function generateClientId() {
-  const ulid = generateULID();
-  return `client_01${ulid}`;
-}
-
-/**
- * Load auth configuration with priority system
- * Priority: FACTORY_API_KEY > refresh token mechanism > client authorization
- */
-function loadAuthConfig() {
-  // 1. Check FACTORY_API_KEY environment variable (highest priority)
-  const factoryKey = process.env.FACTORY_API_KEY;
-  if (factoryKey && factoryKey.trim() !== '') {
-    logInfo('Using fixed API key from FACTORY_API_KEY environment variable');
-    factoryApiKey = factoryKey.trim();
-    authSource = 'factory_key';
-    return { type: 'factory_key', value: factoryKey.trim() };
-  }
-
-  // 2. Check refresh token mechanism (DROID_REFRESH_KEY)
-  const envRefreshKey = process.env.DROID_REFRESH_KEY;
-  if (envRefreshKey && envRefreshKey.trim() !== '') {
-    logInfo('Using refresh token from DROID_REFRESH_KEY environment variable');
-    authSource = 'env';
-    authFilePath = path.join(process.cwd(), 'auth.json');
-    return { type: 'refresh', value: envRefreshKey.trim() };
-  }
-
-  // 3. Check ~/.factory/auth.json
-  const homeDir = os.homedir();
-  const factoryAuthPath = path.join(homeDir, '.factory', 'auth.json');
-  
-  try {
-    if (fs.existsSync(factoryAuthPath)) {
-      const authContent = fs.readFileSync(factoryAuthPath, 'utf-8');
-      const authData = JSON.parse(authContent);
-      
-      if (authData.refresh_token && authData.refresh_token.trim() !== '') {
-        logInfo('Using refresh token from ~/.factory/auth.json');
-        authSource = 'file';
-        authFilePath = factoryAuthPath;
-        
-        // Also load access_token if available
-        if (authData.access_token) {
-          currentApiKey = authData.access_token.trim();
-        }
-        
-        return { type: 'refresh', value: authData.refresh_token.trim() };
-      }
-    }
-  } catch (error) {
-    logError('Error reading ~/.factory/auth.json', error);
-  }
-
-  // 4. No configured auth found - will use client authorization
-  logInfo('No auth configuration found, will use client authorization headers');
-  authSource = 'client';
-  return { type: 'client', value: null };
-}
-
-/**
- * Refresh API key using refresh token
- */
-async function refreshApiKey() {
-  if (!currentRefreshToken) {
-    throw new Error('No refresh token available');
-  }
-
+function getClientId() {
   if (!clientId) {
     clientId = 'client_01HNM792M5G5G1A2THWPXKFMXB';
     logDebug(`Using fixed client ID: ${clientId}`);
   }
+  return clientId;
+}
+
+function parseAuthHeader(headerValue) {
+  if (!headerValue || typeof headerValue !== 'string') {
+    return null;
+  }
+  const parts = headerValue.split(' ');
+  if (parts.length === 1) {
+    return { scheme: null, token: parts[0].trim() };
+  }
+  const [scheme, ...rest] = parts;
+  return { scheme, token: rest.join(' ').trim() };
+}
+
+function isAuthorizedForServerTokens(clientAuthorization) {
+  if (!AUTH_TOKEN) {
+    return false;
+  }
+  const parsed = parseAuthHeader(clientAuthorization);
+  return parsed && parsed.token === AUTH_TOKEN;
+}
+
+function shouldRefresh() {
+  if (!lastRefreshTime) {
+    return true;
+  }
+  const hoursSinceRefresh = (Date.now() - lastRefreshTime) / (1000 * 60 * 60);
+  return hoursSinceRefresh >= REFRESH_INTERVAL_HOURS;
+}
+
+function syncRefreshTokenCache() {
+  const activeRefresh = getActiveRefreshToken();
+  if (!activeRefresh) {
+    cachedRefreshTokenId = null;
+    cachedRefreshTokenValue = null;
+    currentApiKey = null;
+    lastRefreshTime = null;
+    return null;
+  }
+  if (cachedRefreshTokenId !== activeRefresh.id || cachedRefreshTokenValue !== activeRefresh.value) {
+    cachedRefreshTokenId = activeRefresh.id;
+    cachedRefreshTokenValue = activeRefresh.value;
+    currentApiKey = null;
+    lastRefreshTime = null;
+    updateAuthStatus({ activeAccessTokenSnippet: null });
+    logInfo('Active refresh token updated, clearing cached access token');
+  }
+  return activeRefresh;
+}
+
+async function refreshApiKey() {
+  if (!cachedRefreshTokenValue) {
+    const error = new Error('No refresh token available');
+    error.status = 401;
+    throw error;
+  }
 
   logInfo('Refreshing API key...');
+  updateAuthStatus({ lastRefreshStatus: 'in-progress', lastRefreshError: null });
 
   try {
-    // Create form data
     const formData = new URLSearchParams();
     formData.append('grant_type', 'refresh_token');
-    formData.append('refresh_token', currentRefreshToken);
-    formData.append('client_id', clientId);
+    formData.append('refresh_token', cachedRefreshTokenValue);
+    formData.append('client_id', getClientId());
 
     const response = await fetch(REFRESH_URL, {
       method: 'POST',
@@ -148,143 +106,112 @@ async function refreshApiKey() {
     }
 
     const data = await response.json();
-    
-    // Update tokens
     currentApiKey = data.access_token;
-    currentRefreshToken = data.refresh_token;
     lastRefreshTime = Date.now();
 
-    // Log user info
-    if (data.user) {
-      logInfo(`Authenticated as: ${data.user.email} (${data.user.first_name} ${data.user.last_name})`);
-      logInfo(`User ID: ${data.user.id}`);
-      logInfo(`Organization ID: ${data.organization_id}`);
+    if (data.refresh_token && cachedRefreshTokenId) {
+      cachedRefreshTokenValue = data.refresh_token;
+      updateTokenValue('refresh', cachedRefreshTokenId, data.refresh_token);
+      activateToken('refresh', cachedRefreshTokenId);
     }
 
-    // Save tokens to file
-    saveTokens(data.access_token, data.refresh_token);
+    updateAuthStatus({
+      lastRefreshAt: new Date().toISOString(),
+      lastRefreshStatus: 'success',
+      lastRefreshError: null,
+      activeAccessTokenSnippet: maskToken(currentApiKey)
+    });
 
-    logInfo(`New Refresh-Key: ${currentRefreshToken}`);
     logInfo('API key refreshed successfully');
-    return data.access_token;
-
+    return currentApiKey;
   } catch (error) {
+    updateAuthStatus({
+      lastRefreshAt: new Date().toISOString(),
+      lastRefreshStatus: 'error',
+      lastRefreshError: error.message
+    });
     logError('Failed to refresh API key', error);
     throw error;
   }
 }
 
-/**
- * Save tokens to appropriate file
- */
-function saveTokens(accessToken, refreshToken) {
-  try {
-    const authData = {
-      access_token: accessToken,
-      refresh_token: refreshToken,
-      last_updated: new Date().toISOString()
-    };
-
-    // Ensure directory exists
-    const dir = path.dirname(authFilePath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    // If saving to ~/.factory/auth.json, preserve other fields
-    if (authSource === 'file' && fs.existsSync(authFilePath)) {
-      try {
-        const existingData = JSON.parse(fs.readFileSync(authFilePath, 'utf-8'));
-        Object.assign(authData, existingData, {
-          access_token: accessToken,
-          refresh_token: refreshToken,
-          last_updated: authData.last_updated
-        });
-      } catch (error) {
-        logError('Error reading existing auth file, will overwrite', error);
-      }
-    }
-
-    fs.writeFileSync(authFilePath, JSON.stringify(authData, null, 2), 'utf-8');
-    logDebug(`Tokens saved to ${authFilePath}`);
-
-  } catch (error) {
-    logError('Failed to save tokens', error);
-  }
-}
-
-/**
- * Check if API key needs refresh (older than 6 hours)
- */
-function shouldRefresh() {
-  if (!lastRefreshTime) {
-    return true;
-  }
-
-  const hoursSinceRefresh = (Date.now() - lastRefreshTime) / (1000 * 60 * 60);
-  return hoursSinceRefresh >= REFRESH_INTERVAL_HOURS;
-}
-
-/**
- * Initialize auth system - load auth config and setup initial API key if needed
- */
-export async function initializeAuth() {
-  try {
-    const authConfig = loadAuthConfig();
-    
-    if (authConfig.type === 'factory_key') {
-      // Using fixed FACTORY_API_KEY, no refresh needed
-      logInfo('Auth system initialized with fixed API key');
-    } else if (authConfig.type === 'refresh') {
-      // Using refresh token mechanism
-      currentRefreshToken = authConfig.value;
-      
-      // Always refresh on startup to get fresh token
-      await refreshApiKey();
-      logInfo('Auth system initialized with refresh token mechanism');
-    } else {
-      // Using client authorization, no setup needed
-      logInfo('Auth system initialized for client authorization mode');
-    }
-    
-    logInfo('Auth system initialized successfully');
-  } catch (error) {
-    logError('Failed to initialize auth system', error);
+async function ensureAccessTokenValid() {
+  if (!cachedRefreshTokenValue) {
+    const error = new Error('No refresh token configured');
+    error.status = 401;
     throw error;
   }
+  if (!currentApiKey || shouldRefresh()) {
+    await refreshApiKey();
+  }
+  if (!currentApiKey) {
+    const error = new Error('Refresh token did not return access token');
+    error.status = 500;
+    throw error;
+  }
+  return currentApiKey;
 }
 
-/**
- * Get API key based on configured authorization method
- * @param {string} clientAuthorization - Authorization header from client request (optional)
- */
-export async function getApiKey(clientAuthorization = null) {
-  // Priority 1: FACTORY_API_KEY environment variable
-  if (authSource === 'factory_key' && factoryApiKey) {
-    return `Bearer ${factoryApiKey}`;
+export async function initializeAuth() {
+  initializeDashboardState();
+  updateAuthStatus({ authTokenConfigured: Boolean(AUTH_TOKEN) });
+
+  const activeFactory = getActiveFactoryKey();
+  if (activeFactory) {
+    logInfo('Factory API key available via token manager');
   }
-  
-  // Priority 2: Refresh token mechanism
-  if (authSource === 'env' || authSource === 'file') {
-    // Check if we need to refresh
-    if (shouldRefresh()) {
-      logInfo('API key needs refresh (6+ hours old)');
+
+  const activeRefresh = syncRefreshTokenCache();
+  if (activeRefresh) {
+    try {
       await refreshApiKey();
+    } catch (error) {
+      logError('Failed initial refresh with configured token', error);
     }
-
-    if (!currentApiKey) {
-      throw new Error('No API key available from refresh token mechanism.');
-    }
-
-    return `Bearer ${currentApiKey}`;
+  } else if (!activeFactory) {
+    logInfo('No server-managed tokens configured; client authorization headers will be required.');
   }
-  
-  // Priority 3: Client authorization header
+}
+
+export function getDashboardAuthToken() {
+  return AUTH_TOKEN || '';
+}
+
+export async function getApiKey(clientAuthorization = null) {
+  const authorizedForServerTokens = isAuthorizedForServerTokens(clientAuthorization);
+  const timestamp = new Date().toISOString();
+
+  if (authorizedForServerTokens) {
+    const activeFactory = getActiveFactoryKey();
+    if (activeFactory) {
+      const header = `Bearer ${activeFactory.value}`;
+      const snippet = maskToken(activeFactory.value);
+      updateAuthStatus({ lastSource: 'factory', lastUsedAt: timestamp, activeAccessTokenSnippet: snippet });
+      return { header, source: 'factory', tokenSnippet: snippet };
+    }
+
+    const activeRefresh = syncRefreshTokenCache();
+    if (activeRefresh) {
+      await ensureAccessTokenValid();
+      const header = `Bearer ${currentApiKey}`;
+      const snippet = maskToken(currentApiKey);
+      updateAuthStatus({ lastSource: 'refresh', lastUsedAt: timestamp, activeAccessTokenSnippet: snippet });
+      return { header, source: 'refresh', tokenSnippet: snippet };
+    }
+
+    const noTokenError = new Error('Server-managed tokens are not configured. Please add a FACTORY_API_KEY or refresh token.');
+    noTokenError.status = 503;
+    throw noTokenError;
+  }
+
   if (clientAuthorization) {
-    logDebug('Using client authorization header');
-    return clientAuthorization;
+    const parsed = parseAuthHeader(clientAuthorization);
+    const snippet = parsed ? maskToken(parsed.token) : 'N/A';
+    updateAuthStatus({ lastSource: 'client', lastUsedAt: timestamp, lastClientTokenSnippet: snippet });
+    return { header: clientAuthorization, source: 'client', tokenSnippet: snippet };
   }
-  
-  // No authorization available
-  throw new Error('No authorization available. Please configure FACTORY_API_KEY, refresh token, or provide client authorization.');
+
+  const error = new Error('No authorization available. Please configure tokens or provide Authorization header.');
+  error.status = 401;
+  throw error;
 }

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,505 @@
+import express from 'express';
+import { getDashboardAuthToken } from './auth.js';
+import {
+  activateToken,
+  addToken,
+  getDashboardState,
+  removeToken
+} from './state.js';
+
+const dashboardRouter = express.Router();
+
+function renderLoginPage(errorMessage = '') {
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>droid2api Dashboard 登录</title>
+    <style>
+      body { font-family: 'Segoe UI', Arial, sans-serif; background: #0f172a; color: #e2e8f0; margin: 0; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
+      .card { background: rgba(15, 23, 42, 0.85); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 16px; padding: 32px; width: 360px; box-shadow: 0 20px 60px rgba(15, 23, 42, 0.4); }
+      h1 { margin-top: 0; font-size: 24px; text-align: center; }
+      label { display: block; margin-bottom: 8px; font-weight: 600; }
+      input[type="password"] { width: 100%; padding: 12px; border-radius: 8px; border: 1px solid rgba(148, 163, 184, 0.4); background: rgba(15, 23, 42, 0.6); color: #e2e8f0; }
+      input[type="password"]:focus { outline: none; border-color: #38bdf8; box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2); }
+      button { width: 100%; padding: 12px; border: none; border-radius: 8px; background: linear-gradient(135deg, #38bdf8, #6366f1); color: white; font-size: 16px; font-weight: 600; cursor: pointer; margin-top: 16px; }
+      button:hover { opacity: 0.9; }
+      .error { margin-top: 12px; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.5); color: #fca5a5; padding: 10px 12px; border-radius: 8px; }
+      .hint { margin-top: 16px; font-size: 12px; color: #94a3b8; text-align: center; line-height: 1.4; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Dashboard 登录</h1>
+      <form method="post" action="/dashboard/login">
+        <label for="token">请输入 AUTH_TOKEN</label>
+        <input id="token" type="password" name="token" placeholder="AUTH_TOKEN" required autofocus />
+        <button type="submit">进入 Dashboard</button>
+      </form>
+      ${errorMessage ? `<div class="error">${errorMessage}</div>` : ''}
+      <div class="hint">只有知道 AUTH_TOKEN 的用户才能访问 Dashboard 和使用服务器维护的令牌。</div>
+    </div>
+  </body>
+</html>`;
+}
+
+function renderDashboardPage() {
+  const html = `<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>droid2api Dashboard</title>
+    <style>
+      :root { color-scheme: dark; }
+      body { margin: 0; font-family: 'Segoe UI', Arial, sans-serif; background: radial-gradient(circle at top, #1e293b, #0f172a 55%, #020617); color: #e2e8f0; min-height: 100vh; }
+      .container { max-width: 1100px; margin: 0 auto; padding: 32px 24px 48px; }
+      header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 32px; }
+      h1 { font-size: 28px; margin: 0; }
+      .actions { display: flex; gap: 12px; align-items: center; }
+      button, .button { background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: #bfdbfe; border-radius: 8px; padding: 8px 16px; cursor: pointer; font-weight: 600; }
+      button:hover, .button:hover { background: rgba(59, 130, 246, 0.35); }
+      section { background: rgba(15, 23, 42, 0.7); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 16px; padding: 24px; margin-bottom: 24px; box-shadow: 0 12px 40px rgba(2, 6, 23, 0.45); }
+      section h2 { margin-top: 0; font-size: 20px; }
+      table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+      th, td { padding: 10px 12px; border-bottom: 1px solid rgba(148, 163, 184, 0.15); font-size: 13px; text-align: left; }
+      th { text-transform: uppercase; letter-spacing: 0.05em; color: #94a3b8; font-weight: 600; }
+      tr:last-child td { border-bottom: none; }
+      .log-source { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 9999px; font-size: 12px; font-weight: 600; }
+      .source-factory { background: rgba(34, 197, 94, 0.15); color: #4ade80; }
+      .source-refresh { background: rgba(6, 182, 212, 0.15); color: #22d3ee; }
+      .source-client { background: rgba(249, 115, 22, 0.15); color: #fb923c; }
+      .source-none { background: rgba(100, 116, 139, 0.15); color: #cbd5f5; }
+      .token-columns { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; }
+      .token-card { background: rgba(15, 23, 42, 0.6); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 14px; padding: 16px 18px; }
+      .token-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+      .token-item { display: flex; flex-direction: column; gap: 8px; padding: 12px; border-radius: 10px; border: 1px solid rgba(148, 163, 184, 0.15); background: rgba(15, 23, 42, 0.55); }
+      .token-header { display: flex; justify-content: space-between; align-items: center; }
+      .token-label { font-weight: 600; font-size: 14px; }
+      .badge { font-size: 12px; padding: 2px 8px; border-radius: 999px; border: 1px solid rgba(148, 163, 184, 0.4); color: #cbd5f5; }
+      .token-actions { display: flex; gap: 8px; }
+      .token-actions button { padding: 6px 10px; font-size: 12px; border-radius: 6px; background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.35); color: #bfdbfe; cursor: pointer; }
+      .token-actions button.danger { background: rgba(239, 68, 68, 0.18); border-color: rgba(239, 68, 68, 0.4); color: #fca5a5; }
+      form.inline { display: flex; gap: 12px; margin-top: 16px; }
+      form.inline input { flex: 1; padding: 10px 12px; border-radius: 8px; border: 1px solid rgba(148, 163, 184, 0.3); background: rgba(15, 23, 42, 0.5); color: #e2e8f0; }
+      form.inline input:focus { outline: none; border-color: #38bdf8; box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2); }
+      form.inline button { padding: 10px 14px; font-size: 14px; }
+      .status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-top: 12px; }
+      .status-card { background: rgba(15, 23, 42, 0.55); padding: 12px 14px; border-radius: 10px; border: 1px solid rgba(148, 163, 184, 0.2); font-size: 13px; }
+      .status-card strong { display: block; font-size: 12px; color: #94a3b8; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.05em; }
+      .empty { color: #64748b; font-size: 13px; padding: 12px 0; }
+      .error { color: #fca5a5; font-size: 13px; margin-top: 12px; }
+      .logout { background: rgba(239, 68, 68, 0.18); border: 1px solid rgba(239, 68, 68, 0.4); color: #fca5a5; }
+      @media (max-width: 720px) {
+        header { flex-direction: column; align-items: flex-start; gap: 12px; }
+        .actions { width: 100%; justify-content: flex-start; flex-wrap: wrap; }
+        button, .button { width: auto; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>droid2api Dashboard</h1>
+        <div class="actions">
+          <button id="toggle-refresh" type="button">暂停自动刷新</button>
+          <button id="refresh-now" type="button">立即刷新</button>
+          <form method="post" action="/dashboard/logout" style="margin:0">
+            <button class="logout" type="submit">退出登录</button>
+          </form>
+        </div>
+      </header>
+
+      <section>
+        <h2>最近请求 (最多20条)</h2>
+        <div id="logs-empty" class="empty" style="display:none">暂无请求记录</div>
+        <div class="table-wrapper">
+          <table id="logs-table">
+            <thead>
+              <tr>
+                <th>时间</th>
+                <th>方法</th>
+                <th>路径</th>
+                <th>状态码</th>
+                <th>耗时 (ms)</th>
+                <th>客户端 IP</th>
+                <th>Token</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2>令牌状态</h2>
+        <div class="status-grid" id="status-cards"></div>
+      </section>
+
+      <section>
+        <h2>令牌管理</h2>
+        <div class="token-columns">
+          <div class="token-card">
+            <h3>FACTORY_API_KEY</h3>
+            <ul id="factory-list" class="token-list"></ul>
+            <form class="inline" id="factory-form">
+              <input type="text" name="value" placeholder="新增 FACTORY_API_KEY" required />
+              <input type="text" name="label" placeholder="备注 (可选)" />
+              <button type="submit">添加</button>
+            </form>
+          </div>
+          <div class="token-card">
+            <h3>Refresh Token</h3>
+            <ul id="refresh-list" class="token-list"></ul>
+            <form class="inline" id="refresh-form">
+              <input type="text" name="value" placeholder="新增 refresh_token" required />
+              <input type="text" name="label" placeholder="备注 (可选)" />
+              <button type="submit">添加</button>
+            </form>
+          </div>
+        </div>
+        <div id="token-error" class="error" style="display:none"></div>
+      </section>
+    </div>
+
+    <script>
+      const state = {
+        autoRefresh: true,
+        timer: null
+      };
+
+      const sourceClassMap = {
+        factory: 'source-factory',
+        refresh: 'source-refresh',
+        client: 'source-client',
+        none: 'source-none'
+      };
+
+      async function fetchState() {
+        const response = await fetch('/dashboard/api/state', { credentials: 'same-origin' });
+        if (!response.ok) {
+          throw new Error('无法获取 Dashboard 数据');
+        }
+        return response.json();
+      }
+
+      function renderLogs(logs) {
+        const tbody = document.querySelector('#logs-table tbody');
+        const empty = document.getElementById('logs-empty');
+        tbody.innerHTML = '';
+        if (!logs || logs.length === 0) {
+          empty.style.display = 'block';
+          return;
+        }
+        empty.style.display = 'none';
+        logs.forEach((log) => {
+          const tr = document.createElement('tr');
+          const tokenClass = sourceClassMap[log.tokenSource] || 'source-none';
+          const tokenLabel = (log.tokenSource || 'NONE').toUpperCase();
+          const tokenSuffix = log.tokenSnippet ? ' (' + log.tokenSnippet + ')' : '';
+          tr.innerHTML =
+            '<td>' + new Date(log.timestamp).toLocaleString() + '</td>' +
+            '<td>' + log.method + '</td>' +
+            '<td>' + log.path + '</td>' +
+            '<td>' + log.status + '</td>' +
+            '<td>' + log.durationMs + '</td>' +
+            '<td>' + log.clientIp + '</td>' +
+            '<td><span class="log-source ' + tokenClass + '">' + tokenLabel + tokenSuffix + '</span></td>';
+          tbody.appendChild(tr);
+        });
+      }
+
+      function renderStatus(status) {
+        const container = document.getElementById('status-cards');
+        container.innerHTML = '';
+        const items = [
+          { label: 'AUTH_TOKEN 已配置', value: status.authTokenConfigured ? '是' : '否' },
+          { label: '最近使用来源', value: status.lastSource ? status.lastSource.toUpperCase() : '未知' },
+          { label: '最近使用时间', value: status.lastUsedAt ? new Date(status.lastUsedAt).toLocaleString() : '暂无' },
+          { label: '最近刷新时间', value: status.lastRefreshAt ? new Date(status.lastRefreshAt).toLocaleString() : '暂无' },
+          { label: '刷新状态', value: status.lastRefreshStatus ? status.lastRefreshStatus : '未刷新' },
+          { label: '当前服务器 Token', value: status.activeAccessTokenSnippet || '未使用服务器 Token' },
+          { label: '最近客户端 Token', value: status.lastClientTokenSnippet || '暂无' },
+          { label: '刷新错误', value: status.lastRefreshError || '无' }
+        ];
+        items.forEach((item) => {
+          const card = document.createElement('div');
+          card.className = 'status-card';
+          card.innerHTML = '<strong>' + item.label + '</strong>' + item.value;
+          container.appendChild(card);
+        });
+      }
+
+      function renderTokenList(type, list, activeId) {
+        const ul = document.getElementById(type === 'factory' ? 'factory-list' : 'refresh-list');
+        ul.innerHTML = '';
+        if (!list || list.length === 0) {
+          const li = document.createElement('li');
+          li.className = 'empty';
+          li.textContent = '暂无配置';
+          ul.appendChild(li);
+          return;
+        }
+
+        list.forEach((token) => {
+          const li = document.createElement('li');
+          li.className = 'token-item';
+          const isActive = token.id === activeId;
+          const badge = isActive ? '<span class="badge">使用中</span>' : '';
+          const activateDisabled = isActive ? ' disabled' : '';
+          const removeDisabled = token.readOnly ? ' disabled' : '';
+          li.innerHTML =
+            '<div class="token-header">' +
+              '<div>' +
+                '<div class="token-label">' + (token.label || '未命名令牌') + '</div>' +
+                '<div class="token-snippet">' + token.snippet + '</div>' +
+              '</div>' +
+              badge +
+            '</div>' +
+            '<div class="token-actions">' +
+              '<button type="button" data-action="activate" data-type="' + type + '" data-id="' + token.id + '"' + activateDisabled + '>设为当前</button>' +
+              '<button type="button" class="danger" data-action="remove" data-type="' + type + '" data-id="' + token.id + '"' + removeDisabled + '>删除</button>' +
+            '</div>';
+          ul.appendChild(li);
+        });
+      }
+
+      function renderTokens(tokens) {
+        renderTokenList('factory', tokens.factoryKeys, tokens.activeFactoryKeyId);
+        renderTokenList('refresh', tokens.refreshTokens, tokens.activeRefreshTokenId);
+      }
+
+      function showError(message) {
+        const box = document.getElementById('token-error');
+        if (!message) {
+          box.style.display = 'none';
+          return;
+        }
+        box.textContent = message;
+        box.style.display = 'block';
+      }
+
+      async function loadAndRender() {
+        try {
+          const data = await fetchState();
+          renderLogs(data.logs);
+          renderTokens(data.tokens);
+          renderStatus(data.authStatus);
+          showError('');
+        } catch (error) {
+          showError(error.message);
+        }
+      }
+
+      function scheduleRefresh() {
+        clearTimeout(state.timer);
+        if (!state.autoRefresh) {
+          return;
+        }
+        state.timer = setTimeout(async () => {
+          await loadAndRender();
+          scheduleRefresh();
+        }, 5000);
+      }
+
+      document.getElementById('toggle-refresh').addEventListener('click', () => {
+        state.autoRefresh = !state.autoRefresh;
+        document.getElementById('toggle-refresh').textContent = state.autoRefresh ? '暂停自动刷新' : '开启自动刷新';
+        if (state.autoRefresh) {
+          scheduleRefresh();
+        } else {
+          clearTimeout(state.timer);
+        }
+      });
+
+      document.getElementById('refresh-now').addEventListener('click', async () => {
+        await loadAndRender();
+        if (state.autoRefresh) {
+          scheduleRefresh();
+        }
+      });
+
+      async function submitToken(type, form) {
+        const value = form.value.value.trim();
+        const label = form.label.value.trim();
+        if (!value) {
+          showError('请输入有效的 token 值');
+          return;
+        }
+        const response = await fetch('/dashboard/api/tokens', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: JSON.stringify({ type, value, label })
+        });
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({}));
+          showError(error.error || '保存 token 失败');
+          return;
+        }
+        const data = await response.json();
+        renderTokens(data.tokens);
+        renderStatus(data.authStatus);
+        showError('');
+        form.reset();
+      }
+
+      document.getElementById('factory-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        await submitToken('factory', event.target);
+      });
+
+      document.getElementById('refresh-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        await submitToken('refresh', event.target);
+      });
+
+      document.getElementById('factory-list').addEventListener('click', onTokenAction);
+      document.getElementById('refresh-list').addEventListener('click', onTokenAction);
+
+      async function onTokenAction(event) {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        const action = target.getAttribute('data-action');
+        if (!action) return;
+        const type = target.getAttribute('data-type');
+        const id = target.getAttribute('data-id');
+        if (!type || !id) return;
+
+        if (action === 'remove') {
+          const response = await fetch('/dashboard/api/tokens/' + type + '/' + id, {
+            method: 'DELETE',
+            credentials: 'same-origin'
+          });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            showError(error.error || '删除失败');
+            return;
+          }
+          const data = await response.json();
+          renderTokens(data.tokens);
+          renderStatus(data.authStatus);
+          showError('');
+          return;
+        }
+
+        if (action === 'activate') {
+          const response = await fetch('/dashboard/api/tokens/activate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ type, id })
+          });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            showError(error.error || '切换失败');
+            return;
+          }
+          const data = await response.json();
+          renderTokens(data.tokens);
+          renderStatus(data.authStatus);
+          showError('');
+        }
+      }
+
+      loadAndRender().then(scheduleRefresh);
+    </script>
+  </body>
+</html>`;
+  return html.replace(/__TPL__/g, '$');
+}
+
+function ensureDashboardAuth(req, res, next) {
+  if (req.session && req.session.dashboardAuthenticated) {
+    return next();
+  }
+  return res.status(401).json({ error: 'Unauthorized' });
+}
+
+dashboardRouter.get('/', (req, res) => {
+  if (!getDashboardAuthToken()) {
+    return res.send(renderLoginPage('服务器未配置 AUTH_TOKEN，无法登录 Dashboard。'));
+  }
+  if (req.session && req.session.dashboardAuthenticated) {
+    return res.send(renderDashboardPage());
+  }
+  const hasError = req.query.error === '1';
+  const message = hasError ? 'AUTH_TOKEN 不正确' : '';
+  res.send(renderLoginPage(message));
+});
+
+dashboardRouter.post('/login', (req, res) => {
+  const { token } = req.body || {};
+  const authToken = getDashboardAuthToken();
+  if (!authToken) {
+    return res.send(renderLoginPage('服务器未配置 AUTH_TOKEN。'));
+  }
+  if (token && token.trim() === authToken) {
+    if (req.session) {
+      req.session.dashboardAuthenticated = true;
+    }
+    return res.redirect('/dashboard');
+  }
+  return res.send(renderLoginPage('AUTH_TOKEN 不正确')); 
+});
+
+dashboardRouter.post('/logout', (req, res) => {
+  if (req.session) {
+    req.session.dashboardAuthenticated = false;
+    req.session.destroy(() => {
+      res.redirect('/dashboard');
+    });
+  } else {
+    res.redirect('/dashboard');
+  }
+});
+
+dashboardRouter.get('/api/state', ensureDashboardAuth, (req, res) => {
+  res.json(getDashboardState());
+});
+
+dashboardRouter.post('/api/tokens', ensureDashboardAuth, (req, res) => {
+  const { type, value, label } = req.body || {};
+  if (!type || !value) {
+    return res.status(400).json({ error: '缺少必要的字段 type 或 value' });
+  }
+  if (!['factory', 'refresh'].includes(type)) {
+    return res.status(400).json({ error: 'type 必须是 factory 或 refresh' });
+  }
+  try {
+    addToken(type, value, label);
+    return res.json(getDashboardState());
+  } catch (error) {
+    return res.status(400).json({ error: error.message || '保存失败' });
+  }
+});
+
+dashboardRouter.delete('/api/tokens/:type/:id', ensureDashboardAuth, (req, res) => {
+  const { type, id } = req.params;
+  if (!['factory', 'refresh'].includes(type)) {
+    return res.status(400).json({ error: 'type 必须是 factory 或 refresh' });
+  }
+  try {
+    removeToken(type, id);
+    return res.json(getDashboardState());
+  } catch (error) {
+    return res.status(400).json({ error: error.message || '删除失败' });
+  }
+});
+
+dashboardRouter.post('/api/tokens/activate', ensureDashboardAuth, (req, res) => {
+  const { type, id } = req.body || {};
+  if (!type || !id) {
+    return res.status(400).json({ error: '缺少必要的字段 type 或 id' });
+  }
+  if (!['factory', 'refresh'].includes(type)) {
+    return res.status(400).json({ error: 'type 必须是 factory 或 refresh' });
+  }
+  try {
+    activateToken(type, id);
+    return res.json(getDashboardState());
+  } catch (error) {
+    return res.status(400).json({ error: error.message || '切换失败' });
+  }
+});
+
+export default dashboardRouter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "droid2api",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "droid2api",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
+        "express-session": "^1.17.3",
         "node-fetch": "^3.3.2"
       }
     },
@@ -286,6 +287,40 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -629,6 +664,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
@@ -670,6 +714,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -883,6 +936,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.18.2",
+    "express-session": "^1.17.3",
     "node-fetch": "^3.3.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,13 +1,62 @@
 import express from 'express';
+import session from 'express-session';
 import { loadConfig, isDevMode, getPort } from './config.js';
 import { logInfo, logError } from './logger.js';
 import router from './routes.js';
 import { initializeAuth } from './auth.js';
+import dashboardRouter from './dashboard.js';
+import { initializeDashboardState, recordRequestLog } from './state.js';
 
 const app = express();
 
+initializeDashboardState();
+
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
+
+const sessionSecret = process.env.SESSION_SECRET || 'droid2api-dashboard-secret';
+app.use(session({
+  secret: sessionSecret,
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    maxAge: 24 * 60 * 60 * 1000
+  }
+}));
+
+app.use((req, res, next) => {
+  res.locals.tokenInfo = null;
+  next();
+});
+
+app.use((req, res, next) => {
+  const start = typeof process.hrtime.bigint === 'function'
+    ? process.hrtime.bigint()
+    : Date.now();
+
+  res.on('finish', () => {
+    const durationMs = typeof start === 'bigint'
+      ? Number(process.hrtime.bigint() - start) / 1e6
+      : Date.now() - start;
+    const forwarded = req.headers['x-forwarded-for'];
+    const clientIp = (typeof forwarded === 'string' && forwarded.split(',')[0].trim())
+      || req.ip
+      || req.socket?.remoteAddress
+      || 'N/A';
+
+    recordRequestLog({
+      method: req.method,
+      path: req.originalUrl || req.url,
+      status: res.statusCode,
+      durationMs: Math.round(durationMs * 100) / 100,
+      clientIp,
+      tokenSource: res.locals.tokenInfo?.source || 'none',
+      tokenSnippet: res.locals.tokenInfo?.tokenSnippet
+    });
+  });
+
+  next();
+});
 
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
@@ -19,6 +68,8 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+app.use('/dashboard', dashboardRouter);
 
 app.use(router);
 
@@ -115,35 +166,35 @@ app.use((err, req, res, next) => {
     await initializeAuth();
     
     const PORT = getPort();
-  logInfo(`Starting server on port ${PORT}...`);
-  
-  const server = app.listen(PORT)
-    .on('listening', () => {
-      logInfo(`Server running on http://localhost:${PORT}`);
-      logInfo('Available endpoints:');
-      logInfo('  GET  /v1/models');
-      logInfo('  POST /v1/chat/completions');
-      logInfo('  POST /v1/responses');
-      logInfo('  POST /v1/messages');
-    })
-    .on('error', (err) => {
-      if (err.code === 'EADDRINUSE') {
-        console.error(`\n${'='.repeat(80)}`);
-        console.error(`ERROR: Port ${PORT} is already in use!`);
-        console.error('');
-        console.error('Please choose one of the following options:');
-        console.error(`  1. Stop the process using port ${PORT}:`);
-        console.error(`     lsof -ti:${PORT} | xargs kill`);
-        console.error('');
-        console.error('  2. Change the port in config.json:');
-        console.error('     Edit config.json and modify the "port" field');
-        console.error(`${'='.repeat(80)}\n`);
-        process.exit(1);
-      } else {
-        logError('Failed to start server', err);
-        process.exit(1);
-      }
-    });
+    logInfo(`Starting server on port ${PORT}...`);
+
+    const server = app.listen(PORT)
+      .on('listening', () => {
+        logInfo(`Server running on http://localhost:${PORT}`);
+        logInfo('Available endpoints:');
+        logInfo('  GET  /v1/models');
+        logInfo('  POST /v1/chat/completions');
+        logInfo('  POST /v1/responses');
+        logInfo('  POST /v1/messages');
+      })
+      .on('error', (err) => {
+        if (err.code === 'EADDRINUSE') {
+          console.error(`\n${'='.repeat(80)}`);
+          console.error(`ERROR: Port ${PORT} is already in use!`);
+          console.error('');
+          console.error('Please choose one of the following options:');
+          console.error(`  1. Stop the process using port ${PORT}:`);
+          console.error(`     lsof -ti:${PORT} | xargs kill`);
+          console.error('');
+          console.error('  2. Change the port in config.json:');
+          console.error('     Edit config.json and modify the "port" field');
+          console.error(`${'='.repeat(80)}\n`);
+          process.exit(1);
+        } else {
+          logError('Failed to start server', err);
+          process.exit(1);
+        }
+      });
   } catch (error) {
     logError('Failed to start server', error);
     process.exit(1);

--- a/state.js
+++ b/state.js
@@ -1,0 +1,292 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const STORE_PATH = path.join(process.cwd(), 'token-store.json');
+const FACTORY_AUTH_PATH = path.join(os.homedir(), '.factory', 'auth.json');
+const MAX_LOGS = 100;
+
+let initialized = false;
+let requestLogs = [];
+let tokenStore = {
+  factoryKeys: [],
+  refreshTokens: [],
+  activeFactoryKeyId: null,
+  activeRefreshTokenId: null
+};
+let authStatus = {
+  authTokenConfigured: false,
+  lastSource: 'none',
+  lastUsedAt: null,
+  lastRefreshAt: null,
+  lastRefreshStatus: null,
+  lastRefreshError: null,
+  activeAccessTokenSnippet: null,
+  lastClientTokenSnippet: null
+};
+
+function maskToken(value) {
+  if (!value || typeof value !== 'string') {
+    return 'N/A';
+  }
+  if (value.length <= 8) {
+    return value;
+  }
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function persistStore() {
+  try {
+    fs.writeFileSync(
+      STORE_PATH,
+      JSON.stringify(tokenStore, null, 2),
+      'utf-8'
+    );
+  } catch (error) {
+    console.error('[ERROR] Failed to persist token store', error);
+  }
+}
+
+function ensureDirectory(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function loadStore() {
+  if (fs.existsSync(STORE_PATH)) {
+    try {
+      const raw = fs.readFileSync(STORE_PATH, 'utf-8');
+      const parsed = JSON.parse(raw);
+      tokenStore = {
+        factoryKeys: Array.isArray(parsed.factoryKeys) ? parsed.factoryKeys : [],
+        refreshTokens: Array.isArray(parsed.refreshTokens) ? parsed.refreshTokens : [],
+        activeFactoryKeyId: parsed.activeFactoryKeyId || null,
+        activeRefreshTokenId: parsed.activeRefreshTokenId || null
+      };
+    } catch (error) {
+      console.error('[ERROR] Failed to read token store, using defaults', error);
+    }
+  }
+}
+
+function loadLegacyFactoryToken() {
+  if (!fs.existsSync(FACTORY_AUTH_PATH)) {
+    return;
+  }
+  try {
+    const raw = fs.readFileSync(FACTORY_AUTH_PATH, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.refresh_token) {
+        ensureToken('refresh', parsed.refresh_token, 'Factory Refresh Token', true);
+      }
+      if (parsed.access_token) {
+        ensureToken('factory', parsed.access_token, 'Factory Access Token', true);
+      }
+    }
+  } catch (error) {
+    console.error('[ERROR] Failed to load legacy factory auth', error);
+  }
+}
+
+function ensureToken(type, value, label, readOnly = false) {
+  if (typeof value === 'string') {
+    value = value.trim();
+  }
+  if (!value) {
+    return;
+  }
+  const collection = type === 'factory' ? tokenStore.factoryKeys : tokenStore.refreshTokens;
+  const existing = collection.find((item) => item.value === value);
+  if (existing) {
+    if (readOnly) {
+      existing.readOnly = true;
+      if (label) {
+        existing.label = label;
+      }
+    }
+    if (type === 'factory' && !tokenStore.activeFactoryKeyId) {
+      tokenStore.activeFactoryKeyId = existing.id;
+    }
+    if (type === 'refresh' && !tokenStore.activeRefreshTokenId) {
+      tokenStore.activeRefreshTokenId = existing.id;
+    }
+    return;
+  }
+
+  const token = {
+    id: `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    label: label || `${type === 'factory' ? 'Factory' : 'Refresh'} Token`,
+    value,
+    readOnly
+  };
+  collection.push(token);
+  if (type === 'factory' && !tokenStore.activeFactoryKeyId) {
+    tokenStore.activeFactoryKeyId = token.id;
+  }
+  if (type === 'refresh' && !tokenStore.activeRefreshTokenId) {
+    tokenStore.activeRefreshTokenId = token.id;
+  }
+}
+
+function hydrateFromEnvironment() {
+  const envFactory = process.env.FACTORY_API_KEY;
+  if (envFactory && envFactory.trim() !== '') {
+    ensureToken('factory', envFactory.trim(), 'FACTORY_API_KEY (env)', true);
+  }
+  const envRefresh = process.env.DROID_REFRESH_KEY;
+  if (envRefresh && envRefresh.trim() !== '') {
+    ensureToken('refresh', envRefresh.trim(), 'DROID_REFRESH_KEY (env)', true);
+  }
+}
+
+export function initializeDashboardState() {
+  if (initialized) {
+    return;
+  }
+  ensureDirectory(STORE_PATH);
+  loadStore();
+  hydrateFromEnvironment();
+  loadLegacyFactoryToken();
+  persistStore();
+  initialized = true;
+}
+
+function requireInitialization() {
+  if (!initialized) {
+    initializeDashboardState();
+  }
+}
+
+export function recordRequestLog(entry) {
+  requireInitialization();
+  const normalized = {
+    timestamp: entry.timestamp || new Date().toISOString(),
+    method: entry.method,
+    path: entry.path,
+    status: entry.status,
+    durationMs: entry.durationMs,
+    clientIp: entry.clientIp,
+    tokenSource: entry.tokenSource || 'none',
+    tokenSnippet: entry.tokenSnippet ? entry.tokenSnippet : 'N/A'
+  };
+  requestLogs.push(normalized);
+  if (requestLogs.length > MAX_LOGS) {
+    requestLogs = requestLogs.slice(-MAX_LOGS);
+  }
+}
+
+export function getRecentLogs(limit = 20) {
+  requireInitialization();
+  return requestLogs.slice(-limit).reverse();
+}
+
+function sanitizeToken(token) {
+  return {
+    id: token.id,
+    label: token.label,
+    snippet: maskToken(token.value),
+    readOnly: Boolean(token.readOnly)
+  };
+}
+
+export function getTokenStoreSnapshot() {
+  requireInitialization();
+  return {
+    factoryKeys: tokenStore.factoryKeys.map(sanitizeToken),
+    refreshTokens: tokenStore.refreshTokens.map(sanitizeToken),
+    activeFactoryKeyId: tokenStore.activeFactoryKeyId,
+    activeRefreshTokenId: tokenStore.activeRefreshTokenId
+  };
+}
+
+export function getActiveFactoryKey() {
+  requireInitialization();
+  if (!tokenStore.activeFactoryKeyId) {
+    return null;
+  }
+  return tokenStore.factoryKeys.find((token) => token.id === tokenStore.activeFactoryKeyId) || null;
+}
+
+export function getActiveRefreshToken() {
+  requireInitialization();
+  if (!tokenStore.activeRefreshTokenId) {
+    return null;
+  }
+  return tokenStore.refreshTokens.find((token) => token.id === tokenStore.activeRefreshTokenId) || null;
+}
+
+export function addToken(type, value, label) {
+  requireInitialization();
+  ensureToken(type, value, label, false);
+  persistStore();
+  return getTokenStoreSnapshot();
+}
+
+export function removeToken(type, id) {
+  requireInitialization();
+  const collection = type === 'factory' ? tokenStore.factoryKeys : tokenStore.refreshTokens;
+  const index = collection.findIndex((token) => token.id === id);
+  if (index === -1) {
+    throw new Error('Token not found');
+  }
+  if (collection[index].readOnly) {
+    throw new Error('Cannot remove read-only token');
+  }
+  collection.splice(index, 1);
+  if (type === 'factory' && tokenStore.activeFactoryKeyId === id) {
+    tokenStore.activeFactoryKeyId = collection[0]?.id || null;
+  }
+  if (type === 'refresh' && tokenStore.activeRefreshTokenId === id) {
+    tokenStore.activeRefreshTokenId = collection[0]?.id || null;
+  }
+  persistStore();
+  return getTokenStoreSnapshot();
+}
+
+export function activateToken(type, id) {
+  requireInitialization();
+  const collection = type === 'factory' ? tokenStore.factoryKeys : tokenStore.refreshTokens;
+  const exists = collection.some((token) => token.id === id);
+  if (!exists) {
+    throw new Error('Token not found');
+  }
+  if (type === 'factory') {
+    tokenStore.activeFactoryKeyId = id;
+  } else {
+    tokenStore.activeRefreshTokenId = id;
+  }
+  persistStore();
+  return getTokenStoreSnapshot();
+}
+
+export function updateTokenValue(type, id, value) {
+  requireInitialization();
+  const collection = type === 'factory' ? tokenStore.factoryKeys : tokenStore.refreshTokens;
+  const token = collection.find((item) => item.id === id);
+  if (!token) {
+    throw new Error('Token not found');
+  }
+  token.value = value;
+  persistStore();
+}
+
+export function updateAuthStatus(update) {
+  authStatus = { ...authStatus, ...update };
+}
+
+export function getAuthStatus() {
+  return { ...authStatus };
+}
+
+export function getDashboardState(limit = 20) {
+  return {
+    logs: getRecentLogs(limit),
+    tokens: getTokenStoreSnapshot(),
+    authStatus: getAuthStatus()
+  };
+}
+
+export { maskToken };


### PR DESCRIPTION
## Summary
- add an AUTH_TOKEN-protected /dashboard with request log viewer, auto-refresh controls, and UI to add, remove, or activate FACTORY and refresh tokens
- centralize token persistence and request logging in a shared state module and gate server-managed credentials in the auth flow
- wire up session middleware, dashboard routing, and express-session dependency so dashboard access and token usage are tracked consistently

## Testing
- AUTH_TOKEN=testtoken SESSION_SECRET=testsecret npm start

------
https://chatgpt.com/codex/tasks/task_b_68e665041b0083209ed5df5ca8c34309